### PR TITLE
Adds a status endpoint.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 FROM httpd:2-alpine
-RUN echo 'LoadModule proxy_module modules/mod_proxy.so' >> /usr/local/apache2/conf/httpd.conf
-RUN echo 'LoadModule proxy_http_module modules/mod_proxy_http.so'   >> /usr/local/apache2/conf/httpd.conf
-RUN echo 'LoadModule ssl_module modules/mod_ssl.so'   >> /usr/local/apache2/conf/httpd.conf
-RUN echo 'SSLProxyEngine on' >> /usr/local/apache2/conf/httpd.conf
-RUN echo 'ProxyPass "/"  "${ORIGIN_URL}"' >> /usr/local/apache2/conf/httpd.conf
-RUN echo 'ProxyPassReverse "/"  "${ORIGIN_URL}"' >> /usr/local/apache2/conf/httpd.conf
-
-
-
-
+RUN apk add --no-cache curl
+ENV DESTINATION_URL=http://localhost:81 \
+    PRESERVE_HOST=On \
+    SSL_PROXY_ENGINE=On
+COPY conf/httpd.conf /usr/local/apache2/conf/httpd.conf
+COPY conf/extra/httpd-status.conf /usr/local/apache2/conf/extra/httpd-status.conf
+COPY conf/extra/httpd-proxy.conf /usr/local/apache2/conf/extra/httpd-proxy.conf
+RUN apachectl
+HEALTHCHECK \
+    --interval=10s \
+    --timeout=5s   \
+    --retries=10    \
+    CMD curl --fail http://localhost:81/ >/dev/null 2>&1 || exit 1

--- a/README.md
+++ b/README.md
@@ -2,4 +2,18 @@
 
 A simple reverse proxy which allows you to specify the target url via an environment property. The following command is an example of how to run the image with google.co.uk as the target:
 
-`docker run -d -e ORIGIN_URL=https://google.co.uk -p 8080:80 snakeyes30/apache-reverse-proxy`
+```bash
+docker run -it \
+    -p 8080:80 -p 8081:81 \ 
+    -e DESTINATION_URL=https://www.google.com/ \
+    -e PRESERVE_HOST=Off \
+    .../apache-reverse-proxy:latest
+```
+
+| name            | description                                      | Values  |
+|-----------------|--------------------------------------------------|---------|
+| DESTINATION_URL | The target url that the proxy directs traffic to | any url |
+| PRESERVE_HOST   | Should the host header be preserved on requests  | On, Off |
+| SSL_PROXY_ENGINE | Should the proxy be able to request ssl pages   | On, Off |
+
+**Note:** A proxy status can be found at port 81 or port 80 under /_/proxy-status. See the `conf/extra/httpd-status.conf` file for more details. 

--- a/conf/extra/httpd-proxy.conf
+++ b/conf/extra/httpd-proxy.conf
@@ -1,0 +1,17 @@
+Listen 80
+LoadModule proxy_module modules/mod_proxy.so
+LoadModule proxy_http_module modules/mod_proxy_http.so
+LoadModule ssl_module modules/mod_ssl.so
+<VirtualHost *:80>
+  SSLProxyEngine ${SSL_PROXY_ENGINE}
+  ProxyPreserveHost ${PRESERVE_HOST}
+  ProxyPass "/_/proxy-status" !
+  <Location /_/proxy-status>
+    SetHandler server-status
+  </Location>
+  ProxyPass "/"  "${DESTINATION_URL}"
+  ProxyPassReverse "/"  "${DESTINATION_URL}"
+</VirtualHost>
+
+
+

--- a/conf/extra/httpd-status.conf
+++ b/conf/extra/httpd-status.conf
@@ -1,0 +1,7 @@
+Listen 81
+ExtendedStatus On
+<VirtualHost *:81>
+   <Location />
+     SetHandler server-status
+   </Location>
+</VirtualHost>

--- a/conf/httpd.conf
+++ b/conf/httpd.conf
@@ -1,0 +1,110 @@
+
+ServerRoot "/usr/local/apache2"
+LoadModule mpm_event_module modules/mod_mpm_event.so
+LoadModule authn_file_module modules/mod_authn_file.so
+LoadModule authn_core_module modules/mod_authn_core.so
+LoadModule authz_host_module modules/mod_authz_host.so
+LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
+LoadModule authz_user_module modules/mod_authz_user.so
+LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule access_compat_module modules/mod_access_compat.so
+LoadModule auth_basic_module modules/mod_auth_basic.so
+LoadModule reqtimeout_module modules/mod_reqtimeout.so
+LoadModule filter_module modules/mod_filter.so
+LoadModule mime_module modules/mod_mime.so
+LoadModule log_config_module modules/mod_log_config.so
+LoadModule env_module modules/mod_env.so
+LoadModule headers_module modules/mod_headers.so
+LoadModule setenvif_module modules/mod_setenvif.so
+LoadModule version_module modules/mod_version.so
+LoadModule unixd_module modules/mod_unixd.so
+LoadModule status_module modules/mod_status.so
+LoadModule autoindex_module modules/mod_autoindex.so
+<IfModule !mpm_prefork_module>
+	#LoadModule cgid_module modules/mod_cgid.so
+</IfModule>
+<IfModule mpm_prefork_module>
+	#LoadModule cgi_module modules/mod_cgi.so
+</IfModule>
+LoadModule dir_module modules/mod_dir.so
+LoadModule alias_module modules/mod_alias.so
+
+<IfModule unixd_module>
+User daemon
+Group daemon
+</IfModule>
+
+ServerName localhost
+ServerAdmin no-reploy@localhost
+
+<Directory />
+    AllowOverride none
+    Require all denied
+</Directory>
+
+DocumentRoot "/usr/local/apache2/htdocs"
+<Directory "/usr/local/apache2/htdocs">
+    Options Indexes FollowSymLinks
+    AllowOverride None
+    Require all granted
+</Directory>
+
+<IfModule dir_module>
+    DirectoryIndex index.html
+</IfModule>
+
+<Files ".ht*">
+    Require all denied
+</Files>
+
+ErrorLog /proc/self/fd/2
+
+
+# LogLevel: Control the number of messages logged to the error_log.
+# Possible values include: debug, info, notice, warn, error, crit,
+# alert, emerg.
+#
+LogLevel info
+
+<IfModule log_config_module>
+    LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    LogFormat "%h %l %u %t \"%r\" %>s %b" common
+    <IfModule logio_module>
+      # You need to enable mod_logio.c to use %I and %O
+      LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
+    </IfModule>
+    CustomLog /proc/self/fd/1 common
+</IfModule>
+
+<IfModule alias_module>
+    ScriptAlias /cgi-bin/ "/usr/local/apache2/cgi-bin/"
+</IfModule>
+
+<Directory "/usr/local/apache2/cgi-bin">
+    AllowOverride None
+    Options None
+    Require all granted
+</Directory>
+
+<IfModule headers_module>
+    #
+    # Avoid passing HTTP_PROXY environment to CGI's on this or any proxied
+    # backend servers which have lingering "httpoxy" defects.
+    # 'Proxy' request header is undefined by the IETF, not listed by IANA
+    #
+    RequestHeader unset Proxy early
+</IfModule>
+
+Include conf/extra/httpd-status.conf
+Include conf/extra/httpd-proxy.conf
+
+# Configure mod_proxy_html to understand HTML4/XHTML1
+<IfModule proxy_html_module>
+  Include conf/extra/proxy-html.conf
+</IfModule>
+
+
+<IfModule ssl_module>
+SSLRandomSeed startup builtin
+SSLRandomSeed connect builtin
+</IfModule>


### PR DESCRIPTION
The change adds
- Status Page at:
  - http://host:81/
  - http://host:80/_/proxy-status
- Built-In Docker Healtcheck. 
- Environment options to switch on `PreserveHost` or to switch of SSLProxyEngine.